### PR TITLE
Убирает лишний отступ у заголовка на странице подкаста

### DIFF
--- a/src/pages/episode.njk
+++ b/src/pages/episode.njk
@@ -7,7 +7,7 @@
             <time class="podcast__date" datetime="{{ episode.date | isoDate }}">
                 {{ episode.date | ruDate }}
             </time>
-            <h1 class="article__title podcast__title">
+            <h1 class="podcast__title">
                 {{ episode.data.title }}
             </h1>
             <dl class="podcast__participants">


### PR DESCRIPTION
До:

![image.png](https://github.com/user-attachments/assets/b7c5dd1d-556e-41ad-a302-840ddabc1892)

После:

![image.png](https://github.com/user-attachments/assets/24efeb62-5e6f-489d-bf7a-054b68579819)
